### PR TITLE
feat: support multiple VictoriaMetrics instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,33 @@ You can use two options to connect to your VictoriaMetrics instance:
 - Using `VM_INSTANCE_ENTRYPOINT` + `VM_INSTANCE_TYPE` + `VM_INSTANCE_BEARER_TOKEN` (optional) environment variables to connect to any single-node or cluster instance of VictoriaMetrics.
 - Using `VMC_API_KEY` environment variable to work with your [VictoriaMetrics Cloud](https://victoriametrics.com/products/cloud/) instances.
 
+### Multiple Instances Support
+
+You can configure the MCP Server to work with multiple VictoriaMetrics instances simultaneously.
+
+To enable multiple instances, set the `VM_ENVIRONMENTS` environment variable to a comma-separated list of environment names. Then, for each environment, you can provide its specific configuration using the prefix `VM_INSTANCE_<UPPERCASE_ENV>_`.
+
+Example configuration for multiple servers:
+
+```bash
+# Define available environments
+export VM_ENVIRONMENTS="demo,prod"
+export VM_DEFAULT_ENVIRONMENT="demo"
+
+# 'demo' instance configuration
+export VM_INSTANCE_DEMO_ENTRYPOINT="http://demo.victoriametrics.com"
+export VM_INSTANCE_DEMO_TYPE="single"
+export VM_INSTANCE_DEMO_BEARER_TOKEN="demo-token"
+
+# 'prod' instance configuration
+export VM_INSTANCE_PROD_ENTRYPOINT="http://prod.victoriametrics.com"
+export VM_INSTANCE_PROD_TYPE="cluster"
+```
+
+If `VM_ENVIRONMENTS` is not set, the server defaults to a single "default" environment configured via the standard `VM_INSTANCE_ENTRYPOINT` variables.
+
+Once multiple servers are configured, you can specify the target environment using the optional `env` argument in any tool that interacts with the server. If `env` is not provided, the default environment (or the first one listed in `VM_ENVIRONMENTS`) is used.
+
 ### Modes
 
 MCP Server supports the following modes of operation (transports):

--- a/cmd/mcp-victoriametrics/config/config.go
+++ b/cmd/mcp-victoriametrics/config/config.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/auth"
 	vmcloud "github.com/VictoriaMetrics/victoriametrics-cloud-api-go/v1"
@@ -14,27 +16,70 @@ import (
 
 const (
 	toolsDisabledByDefault = "export,flags,metric_relabel_debug,downsampling_filters_debug,retention_filters_debug,test_rules"
+	defaultEnvironmentName = "default"
 )
 
+type InstanceConfig struct {
+	name            string
+	entrypoint      string
+	instanceType    string
+	bearerToken     string
+	customHeaders   map[string]string
+	defaultTenantID string
+	apiKey          string
+	entryPointURL   *url.URL
+	vmc             *vmcloud.VMCloudAPIClient
+}
+
+func (s *InstanceConfig) Name() string {
+	return s.name
+}
+
+func (s *InstanceConfig) IsCluster() bool {
+	return s.instanceType == "cluster"
+}
+
+func (s *InstanceConfig) IsSingle() bool {
+	return s.instanceType == "single"
+}
+
+func (s *InstanceConfig) IsCloud() bool {
+	return s.vmc != nil
+}
+
+func (s *InstanceConfig) VMC() *vmcloud.VMCloudAPIClient {
+	return s.vmc
+}
+
+func (s *InstanceConfig) BearerToken() string {
+	return s.bearerToken
+}
+
+func (s *InstanceConfig) EntryPointURL() *url.URL {
+	return s.entryPointURL
+}
+
+func (s *InstanceConfig) CustomHeaders() map[string]string {
+	return s.customHeaders
+}
+
+func (s *InstanceConfig) DefaultTenantID() string {
+	return s.defaultTenantID
+}
+
 type Config struct {
-	serverMode        string
-	listenAddr        string
-	entrypoint        string
-	instanceType      string
-	bearerToken       string
-	disabledTools     map[string]bool
-	apiKey            string
-	heartbeatInterval time.Duration
-	disableResources  bool
-	customHeaders     map[string]string
-	defaultTenantID   string
+	serverMode         string
+	listenAddr         string
+	disabledTools      map[string]bool
+	heartbeatInterval  time.Duration
+	disableResources   bool
+	environments       map[string]*InstanceConfig
+	environmentOrder   []string
+	defaultEnvironment string
 
 	// Logging configuration
 	logFormat string
 	logLevel  string
-
-	entryPointURL *url.URL
-	vmc           *vmcloud.VMCloudAPIClient
 }
 
 func InitConfig() (*Config, error) {
@@ -48,24 +93,6 @@ func InitConfig() (*Config, error) {
 			tool = strings.Trim(tool, " ,")
 			if tool != "" {
 				disabledToolsMap[tool] = true
-			}
-		}
-	}
-
-	customHeaders := os.Getenv("VM_INSTANCE_HEADERS")
-	customHeadersMap := make(map[string]string)
-	if customHeaders != "" {
-		for _, header := range strings.Split(customHeaders, ",") {
-			header = strings.TrimSpace(header)
-			if header != "" {
-				parts := strings.SplitN(header, "=", 2)
-				if len(parts) == 2 {
-					key := strings.TrimSpace(parts[0])
-					value := strings.TrimSpace(parts[1])
-					if key != "" && value != "" {
-						customHeadersMap[key] = value
-					}
-				}
 			}
 		}
 	}
@@ -108,37 +135,17 @@ func InitConfig() (*Config, error) {
 	if logLevel != "debug" && logLevel != "info" && logLevel != "warn" && logLevel != "error" {
 		return nil, fmt.Errorf("MCP_LOG_LEVEL must be 'debug', 'info', 'warn' or 'error'")
 	}
+
 	result := &Config{
 		serverMode:        strings.ToLower(os.Getenv("MCP_SERVER_MODE")),
 		listenAddr:        os.Getenv("MCP_LISTEN_ADDR"),
-		entrypoint:        os.Getenv("VM_INSTANCE_ENTRYPOINT"),
-		instanceType:      os.Getenv("VM_INSTANCE_TYPE"),
-		bearerToken:       os.Getenv("VM_INSTANCE_BEARER_TOKEN"),
 		disabledTools:     disabledToolsMap,
-		apiKey:            os.Getenv("VMC_API_KEY"),
 		heartbeatInterval: heartbeatInterval,
 		disableResources:  disableResources,
-		customHeaders:     customHeadersMap,
 		logFormat:         logFormat,
 		logLevel:          logLevel,
-		defaultTenantID:   "0",
 	}
-	// Left for backward compatibility
-	if result.listenAddr == "" {
-		result.listenAddr = os.Getenv("MCP_SSE_ADDR")
-	}
-	if result.entrypoint == "" && result.apiKey == "" {
-		return nil, fmt.Errorf("VM_INSTANCE_ENTRYPOINT or VMC_API_KEY is not set")
-	}
-	if result.entrypoint != "" && result.apiKey != "" {
-		return nil, fmt.Errorf("VM_INSTANCE_ENTRYPOINT and VMC_API_KEY cannot be set at the same time")
-	}
-	if result.entrypoint != "" && result.instanceType == "" {
-		return nil, fmt.Errorf("VM_INSTANCE_TYPE is not set")
-	}
-	if result.entrypoint != "" && result.instanceType != "cluster" && result.instanceType != "single" {
-		return nil, fmt.Errorf("VM_INSTANCE_TYPE must be 'single' or 'cluster'")
-	}
+
 	if result.serverMode != "" && result.serverMode != "stdio" && result.serverMode != "sse" && result.serverMode != "http" {
 		return nil, fmt.Errorf("MCP_SERVER_MODE must be 'stdio', 'sse' or 'http'")
 	}
@@ -146,41 +153,324 @@ func InitConfig() (*Config, error) {
 		result.serverMode = "stdio"
 	}
 	if result.listenAddr == "" {
+		result.listenAddr = os.Getenv("MCP_SSE_ADDR")
+	}
+	if result.listenAddr == "" {
 		result.listenAddr = "localhost:8080"
 	}
 
-	var err error
-	if result.apiKey == "" {
-		result.entryPointURL, err = url.Parse(result.entrypoint)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse URL from VM_INSTANCE_ENTRYPOINT: %w", err)
-		}
+	environments, environmentOrder, defaultEnvironment, err := initEnvironmentConfigs()
+	if err != nil {
+		return nil, err
 	}
-	if result.apiKey != "" {
-		result.vmc, err = vmcloud.New(result.apiKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create VMCloud API client: %w", err)
-		}
-	}
-
-	defaultTenantID := strings.ToLower(os.Getenv("VM_DEFAULT_TENANT_ID"))
-	if defaultTenantID != "" {
-		tenantID, err := auth.NewToken(defaultTenantID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse VM_DEFAULT_TENANT_ID %q: %w", defaultTenantID, err)
-		}
-		result.defaultTenantID = tenantID.String()
-	}
+	result.environments = environments
+	result.environmentOrder = environmentOrder
+	result.defaultEnvironment = defaultEnvironment
 
 	return result, nil
 }
 
+func initEnvironmentConfigs() (map[string]*InstanceConfig, []string, string, error) {
+	if envNamesValue := os.Getenv("VM_ENVIRONMENTS"); envNamesValue != "" {
+		if err := validateNoStandardInstanceConfig(); err != nil {
+			return nil, nil, "", err
+		}
+
+		envNames, err := parseEnvironmentNames(envNamesValue)
+		if err != nil {
+			return nil, nil, "", err
+		}
+
+		defaultEnvironment := strings.TrimSpace(strings.ToLower(os.Getenv("VM_DEFAULT_ENVIRONMENT")))
+		if defaultEnvironment == "" {
+			defaultEnvironment = envNames[0]
+		}
+		if !slices.Contains(envNames, defaultEnvironment) {
+			return nil, nil, "", fmt.Errorf("VM_DEFAULT_ENVIRONMENT %q is not listed in VM_ENVIRONMENTS", defaultEnvironment)
+		}
+
+		environments := make(map[string]*InstanceConfig, len(envNames))
+		for _, envName := range envNames {
+			prefix := environmentVarPrefix(envName)
+			instance, err := newInstanceConfig(
+				envName,
+				os.Getenv(prefix+"ENTRYPOINT"),
+				os.Getenv(prefix+"TYPE"),
+				os.Getenv(prefix+"BEARER_TOKEN"),
+				parseHeaders(os.Getenv(prefix+"HEADERS")),
+				os.Getenv(prefix+"DEFAULT_TENANT_ID"),
+				os.Getenv("VMC_"+strings.ToUpper(envName)+"_API_KEY"),
+			)
+			if err != nil {
+				return nil, nil, "", err
+			}
+			environments[envName] = instance
+		}
+
+		return environments, envNames, defaultEnvironment, nil
+	}
+
+	instance, err := newInstanceConfig(
+		defaultEnvironmentName,
+		os.Getenv("VM_INSTANCE_ENTRYPOINT"),
+		os.Getenv("VM_INSTANCE_TYPE"),
+		os.Getenv("VM_INSTANCE_BEARER_TOKEN"),
+		parseHeaders(os.Getenv("VM_INSTANCE_HEADERS")),
+		os.Getenv("VM_DEFAULT_TENANT_ID"),
+		os.Getenv("VMC_API_KEY"),
+	)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return map[string]*InstanceConfig{defaultEnvironmentName: instance}, []string{defaultEnvironmentName}, defaultEnvironmentName, nil
+}
+
+func validateNoStandardInstanceConfig() error {
+	for _, envVar := range []string{
+		"VM_INSTANCE_ENTRYPOINT",
+		"VM_INSTANCE_TYPE",
+		"VM_INSTANCE_BEARER_TOKEN",
+		"VM_INSTANCE_HEADERS",
+		"VM_DEFAULT_TENANT_ID",
+		"VMC_API_KEY",
+	} {
+		if os.Getenv(envVar) != "" {
+			return fmt.Errorf("%s cannot be combined with VM_ENVIRONMENTS; use per-environment variables instead", envVar)
+		}
+	}
+	return nil
+}
+
+func parseEnvironmentNames(value string) ([]string, error) {
+	names := make([]string, 0)
+	seenNames := make(map[string]struct{})
+	seenPrefixes := make(map[string]string)
+
+	for _, rawName := range strings.Split(value, ",") {
+		name := strings.TrimSpace(strings.ToLower(rawName))
+		if name == "" {
+			continue
+		}
+		if !isValidEnvironmentName(name) {
+			return nil, fmt.Errorf("VM_ENVIRONMENTS contains invalid env name %q; only letters, numbers, dashes, and underscores are allowed", rawName)
+		}
+		if _, ok := seenNames[name]; ok {
+			return nil, fmt.Errorf("VM_ENVIRONMENTS contains duplicate env name %q", name)
+		}
+
+		prefix := environmentVarPrefix(name)
+		if existingName, ok := seenPrefixes[prefix]; ok {
+			return nil, fmt.Errorf("VM_ENVIRONMENTS names %q and %q map to the same environment variable prefix %q", existingName, name, prefix)
+		}
+
+		seenNames[name] = struct{}{}
+		seenPrefixes[prefix] = name
+		names = append(names, name)
+	}
+
+	if len(names) == 0 {
+		return nil, fmt.Errorf("VM_ENVIRONMENTS is set but does not contain any env names")
+	}
+
+	return names, nil
+}
+
+func isValidEnvironmentName(value string) bool {
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func environmentVarPrefix(name string) string {
+	var b strings.Builder
+	b.WriteString("VM_INSTANCE_")
+	for _, r := range strings.ToUpper(name) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	b.WriteByte('_')
+	return b.String()
+}
+
+func newInstanceConfig(name, entrypoint, instanceType, bearerToken string, customHeaders map[string]string, defaultTenantID, apiKey string) (*InstanceConfig, error) {
+	if entrypoint == "" && apiKey == "" {
+		if name == defaultEnvironmentName {
+			return nil, fmt.Errorf("VM_INSTANCE_ENTRYPOINT or VMC_API_KEY is not set")
+		}
+		return nil, fmt.Errorf("%sENTRYPOINT or VMC_%s_API_KEY is not set", environmentVarPrefix(name), strings.ToUpper(name))
+	}
+	if entrypoint != "" && apiKey != "" {
+		return nil, fmt.Errorf("env %q: ENTRYPOINT and API_KEY cannot be set at the same time", name)
+	}
+	if entrypoint != "" && instanceType == "" {
+		return nil, fmt.Errorf("env %q: INSTANCE_TYPE is not set", name)
+	}
+	if entrypoint != "" && instanceType != "cluster" && instanceType != "single" {
+		return nil, fmt.Errorf("env %q: INSTANCE_TYPE must be 'single' or 'cluster'", name)
+	}
+
+	var entryPointURL *url.URL
+	var vmc *vmcloud.VMCloudAPIClient
+	var err error
+
+	if apiKey == "" {
+		entryPointURL, err = url.Parse(entrypoint)
+		if err != nil {
+			return nil, fmt.Errorf("env %q: failed to parse URL from ENTRYPOINT: %w", name, err)
+		}
+	} else {
+		vmc, err = vmcloud.New(apiKey)
+		if err != nil {
+			return nil, fmt.Errorf("env %q: failed to create VMCloud API client: %w", name, err)
+		}
+	}
+
+	resolvedTenantID := "0"
+	if defaultTenantID != "" {
+		tenantID, err := auth.NewToken(defaultTenantID)
+		if err != nil {
+			return nil, fmt.Errorf("env %q: failed to parse DEFAULT_TENANT_ID %q: %w", name, defaultTenantID, err)
+		}
+		resolvedTenantID = tenantID.String()
+	}
+
+	return &InstanceConfig{
+		name:            name,
+		entrypoint:      entrypoint,
+		instanceType:    instanceType,
+		bearerToken:     bearerToken,
+		customHeaders:   customHeaders,
+		defaultTenantID: resolvedTenantID,
+		apiKey:          apiKey,
+		entryPointURL:   entryPointURL,
+		vmc:             vmc,
+	}, nil
+}
+
+func parseHeaders(value string) map[string]string {
+	headers := make(map[string]string)
+	if value == "" {
+		return headers
+	}
+
+	for _, header := range strings.Split(value, ",") {
+		header = strings.TrimSpace(header)
+		if header == "" {
+			continue
+		}
+
+		parts := strings.SplitN(header, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		headerValue := strings.TrimSpace(parts[1])
+		if key == "" || headerValue == "" {
+			continue
+		}
+		headers[key] = headerValue
+	}
+
+	return headers
+}
+
+func (c *Config) DefaultEnvironment() string {
+	return c.defaultEnvironment
+}
+
+func (c *Config) EnvironmentNames() []string {
+	return slices.Clone(c.environmentOrder)
+}
+
+func (c *Config) Environment(name string) (*InstanceConfig, error) {
+	if len(c.environments) == 0 {
+		return nil, fmt.Errorf("no VictoriaMetrics environments configured")
+	}
+
+	resolvedName := strings.TrimSpace(strings.ToLower(name))
+	if resolvedName == "" {
+		resolvedName = c.defaultEnvironment
+	}
+
+	env, ok := c.environments[resolvedName]
+	if !ok {
+		return nil, fmt.Errorf("unknown VictoriaMetrics env %q; available envs: %s", resolvedName, strings.Join(c.environmentOrder, ", "))
+	}
+	return env, nil
+}
+
+// Helper methods for accessing default environment configuration
 func (c *Config) IsCluster() bool {
-	return c.instanceType == "cluster"
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.IsCluster()
+	}
+	return false
 }
 
 func (c *Config) IsSingle() bool {
-	return c.instanceType == "single"
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.IsSingle()
+	}
+	return false
+}
+
+func (c *Config) IsCloud() bool {
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.IsCloud()
+	}
+	return false
+}
+
+func (c *Config) VMC() *vmcloud.VMCloudAPIClient {
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.vmc
+	}
+	return nil
+}
+
+func (c *Config) BearerToken() string {
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.BearerToken()
+	}
+	return ""
+}
+
+func (c *Config) EntryPointURL() *url.URL {
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.EntryPointURL()
+	}
+	return nil
+}
+
+func (c *Config) CustomHeaders() map[string]string {
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.CustomHeaders()
+	}
+	return nil
+}
+
+func (c *Config) DefaultTenantID() string {
+	s, _ := c.Environment("")
+	if s != nil {
+		return s.DefaultTenantID()
+	}
+	return "0"
 }
 
 func (c *Config) IsStdio() bool {
@@ -195,24 +485,8 @@ func (c *Config) ServerMode() string {
 	return c.serverMode
 }
 
-func (c *Config) IsCloud() bool {
-	return c.vmc != nil
-}
-
-func (c *Config) VMC() *vmcloud.VMCloudAPIClient {
-	return c.vmc
-}
-
 func (c *Config) ListenAddr() string {
 	return c.listenAddr
-}
-
-func (c *Config) BearerToken() string {
-	return c.bearerToken
-}
-
-func (c *Config) EntryPointURL() *url.URL {
-	return c.entryPointURL
 }
 
 func (c *Config) IsToolDisabled(toolName string) bool {
@@ -231,18 +505,10 @@ func (c *Config) HeartbeatInterval() time.Duration {
 	return c.heartbeatInterval
 }
 
-func (c *Config) CustomHeaders() map[string]string {
-	return c.customHeaders
-}
-
 func (c *Config) LogFormat() string {
 	return c.logFormat
 }
 
 func (c *Config) LogLevel() string {
 	return c.logLevel
-}
-
-func (c *Config) DefaultTenantID() string {
-	return c.defaultTenantID
 }

--- a/cmd/mcp-victoriametrics/config/config_test.go
+++ b/cmd/mcp-victoriametrics/config/config_test.go
@@ -1,342 +1,124 @@
 package config
 
 import (
-	"net/url"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestInitConfig(t *testing.T) {
 	// Save original environment variables
-	originalEntrypoint := os.Getenv("VM_INSTANCE_ENTRYPOINT")
-	originalInstanceType := os.Getenv("VM_INSTANCE_TYPE")
-	originalServerMode := os.Getenv("MCP_SERVER_MODE")
-	originalSSEAddr := os.Getenv("MCP_SSE_ADDR")
-	originalBearerToken := os.Getenv("VM_INSTANCE_BEARER_TOKEN")
-	originalHeartbeatInterval := os.Getenv("MCP_HEARTBEAT_INTERVAL")
-	originalHeaders := os.Getenv("VM_INSTANCE_HEADERS")
+	envVars := []string{
+		"VM_INSTANCE_ENTRYPOINT",
+		"VM_INSTANCE_TYPE",
+		"VM_INSTANCE_BEARER_TOKEN",
+		"VM_INSTANCE_HEADERS",
+		"VM_DEFAULT_TENANT_ID",
+		"VM_ENVIRONMENTS",
+		"VM_DEFAULT_ENVIRONMENT",
+		"VMC_API_KEY",
+		"MCP_SERVER_MODE",
+		"MCP_SSE_ADDR",
+		"MCP_HEARTBEAT_INTERVAL",
+	}
+	originalEnv := make(map[string]string)
+	for _, v := range envVars {
+		originalEnv[v] = os.Getenv(v)
+	}
 
 	// Restore environment variables after test
 	defer func() {
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", originalEntrypoint)
-		os.Setenv("VM_INSTANCE_TYPE", originalInstanceType)
-		os.Setenv("MCP_SERVER_MODE", originalServerMode)
-		os.Setenv("MCP_SSE_ADDR", originalSSEAddr)
-		os.Setenv("VM_INSTANCE_BEARER_TOKEN", originalBearerToken)
-		os.Setenv("MCP_HEARTBEAT_INTERVAL", originalHeartbeatInterval)
-		os.Setenv("VM_INSTANCE_HEADERS", originalHeaders)
+		for k, v := range originalEnv {
+			if v != "" {
+				os.Setenv(k, v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
 	}()
 
-	// Test case 1: Valid configuration
-	t.Run("Valid configuration", func(t *testing.T) {
-		// Set environment variables
+	// Helper to clear env
+	clearEnv := func() {
+		for _, v := range envVars {
+			os.Unsetenv(v)
+		}
+		// Also clear some prefixed ones we might use
+		os.Unsetenv("VM_INSTANCE_DEFAULT_ENTRYPOINT")
+		os.Unsetenv("VM_INSTANCE_DEFAULT_TYPE")
+		os.Unsetenv("VM_INSTANCE_DEMO_ENTRYPOINT")
+		os.Unsetenv("VM_INSTANCE_DEMO_TYPE")
+	}
+
+	// Test case 1: Valid configuration (standard single instance mode)
+	t.Run("Valid configuration standard", func(t *testing.T) {
+		clearEnv()
 		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
 		os.Setenv("VM_INSTANCE_TYPE", "single")
 		os.Setenv("MCP_SERVER_MODE", "stdio")
-		os.Setenv("MCP_SSE_ADDR", "localhost:8080")
 		os.Setenv("VM_INSTANCE_BEARER_TOKEN", "test-token")
 
-		// Initialize config
 		cfg, err := InitConfig()
-
-		// Check for errors
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// Check config values
 		if cfg.BearerToken() != "test-token" {
 			t.Errorf("Expected bearer token 'test-token', got: %s", cfg.BearerToken())
 		}
 		if !cfg.IsSingle() {
 			t.Error("Expected IsSingle() to be true")
 		}
-		if cfg.IsCluster() {
-			t.Error("Expected IsCluster() to be false")
-		}
 		if !cfg.IsStdio() {
 			t.Error("Expected IsStdio() to be true")
 		}
-		if cfg.IsSSE() {
-			t.Error("Expected IsSSE() to be false")
-		}
 		if cfg.ListenAddr() != "localhost:8080" {
-			t.Errorf("Expected SSE address 'localhost:8080', got: %s", cfg.ListenAddr())
-		}
-		expectedURL, _ := url.Parse("http://example.com")
-		if cfg.EntryPointURL().String() != expectedURL.String() {
-			t.Errorf("Expected entrypoint URL 'http://example.com', got: %s", cfg.EntryPointURL().String())
-		}
-		if !cfg.IsSingle() {
-			t.Error("Expected IsSingle() to be true")
-		}
-		if cfg.IsCluster() {
-			t.Error("Expected IsCluster() to be false")
+			t.Errorf("Expected address 'localhost:8080', got: %s", cfg.ListenAddr())
 		}
 	})
 
-	// Test case 2: Missing entrypoint
-	t.Run("Missing entrypoint", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "")
-		os.Setenv("VM_INSTANCE_TYPE", "single")
+	// Test case 2: Multi-instance configuration
+	t.Run("Multi-instance configuration", func(t *testing.T) {
+		clearEnv()
+		os.Setenv("VM_ENVIRONMENTS", "default,demo")
+		os.Setenv("VM_INSTANCE_DEFAULT_ENTRYPOINT", "http://default.com")
+		os.Setenv("VM_INSTANCE_DEFAULT_TYPE", "single")
+		os.Setenv("VM_INSTANCE_DEMO_ENTRYPOINT", "http://demo.com")
+		os.Setenv("VM_INSTANCE_DEMO_TYPE", "cluster")
 
-		// Initialize config
+		cfg, err := InitConfig()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Check default
+		def, err := cfg.Environment("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if def.EntryPointURL().String() != "http://default.com" {
+			t.Errorf("Expected http://default.com, got %s", def.EntryPointURL())
+		}
+
+		// Check demo
+		demo, err := cfg.Environment("demo")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if demo.EntryPointURL().String() != "http://demo.com" {
+			t.Errorf("Expected http://demo.com, got %s", demo.EntryPointURL())
+		}
+		if !demo.IsCluster() {
+			t.Error("Expected demo to be cluster")
+		}
+	})
+
+	// Test case 3: Conflict validation
+	t.Run("Variable conflict", func(t *testing.T) {
+		clearEnv()
+		os.Setenv("VM_ENVIRONMENTS", "demo")
+		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://default.com") // standard var
+
 		_, err := InitConfig()
-
-		// Check for errors
 		if err == nil {
-			t.Fatal("Expected error for missing entrypoint, got nil")
+			t.Fatal("Expected error when mixing VM_ENVIRONMENTS and standard vars")
 		}
-	})
-
-	// Test case 3: Missing instance type
-	t.Run("Missing instance type", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "")
-
-		// Initialize config
-		_, err := InitConfig()
-
-		// Check for errors
-		if err == nil {
-			t.Fatal("Expected error for missing instance type, got nil")
-		}
-	})
-
-	// Test case 4: Invalid instance type
-	t.Run("Invalid instance type", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "invalid")
-
-		// Initialize config
-		_, err := InitConfig()
-
-		// Check for errors
-		if err == nil {
-			t.Fatal("Expected error for invalid instance type, got nil")
-		}
-	})
-
-	// Test case 5: Invalid server mode
-	t.Run("Invalid server mode", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "single")
-		os.Setenv("MCP_SERVER_MODE", "invalid")
-
-		// Initialize config
-		_, err := InitConfig()
-
-		// Check for errors
-		if err == nil {
-			t.Fatal("Expected error for invalid server mode, got nil")
-		}
-	})
-
-	// Test case 6: Default values
-	t.Run("Default values", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "single")
-		os.Setenv("MCP_SERVER_MODE", "")
-		os.Setenv("MCP_SSE_ADDR", "")
-
-		// Initialize config
-		cfg, err := InitConfig()
-
-		// Check for errors
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		// Check default values
-		if !cfg.IsStdio() {
-			t.Error("Expected default server mode to be stdio")
-		}
-		if cfg.ListenAddr() != "localhost:8080" {
-			t.Errorf("Expected default SSE address 'localhost:8080', got: %s", cfg.ListenAddr())
-		}
-		if !cfg.IsSingle() {
-			t.Error("Expected IsSingle() to be true")
-		}
-		if cfg.IsCluster() {
-			t.Error("Expected IsCluster() to be false")
-		}
-	})
-
-	// Test case 7: Cluster
-	t.Run("Missing entrypoint", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "cluster")
-
-		// Initialize config
-		cfg, err := InitConfig()
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		// Check values
-		if cfg.IsSingle() {
-			t.Error("Expected IsSingle() to be true")
-		}
-		if !cfg.IsCluster() {
-			t.Error("Expected IsCluster() to be false")
-		}
-	})
-	// Test case 8: Heartbeat interval
-	t.Run("Correct heartbeat interval", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "single")
-		os.Setenv("MCP_HEARTBEAT_INTERVAL", "30s")
-		// Initialize config
-		cfg, err := InitConfig()
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-		// Check values
-		if cfg.HeartbeatInterval() != 30*time.Second {
-			t.Errorf("Expected heartbeat interval to be 30 seconds, got: %d", cfg.HeartbeatInterval())
-		}
-	})
-	// Test case 9: Invalid heartbeat interval
-	t.Run("Incorrect heartbeat interval", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "single")
-		os.Setenv("MCP_HEARTBEAT_INTERVAL", "123")
-		// Initialize config
-		_, err := InitConfig()
-		if err != nil && err.Error() != "failed to parse MCP_HEARTBEAT_INTERVAL: time: missing unit in duration \"123\"" {
-			t.Errorf("Expected error 'invalid heartbeat interval: 123', got: %v", err)
-		}
-
-		os.Setenv("MCP_HEARTBEAT_INTERVAL", originalHeartbeatInterval)
-	})
-
-	// Test case 10: Custom headers parsing
-	t.Run("Custom headers parsing", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_HEADERS", "CF-Access-Client-Id=test-client-id,CF-Access-Client-Secret=test-client-secret,Custom-Header=test-value")
-
-		// Initialize config
-		cfg, err := InitConfig()
-
-		// Check for errors
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		// Check custom headers
-		headers := cfg.CustomHeaders()
-		expectedHeaders := map[string]string{
-			"CF-Access-Client-Id":     "test-client-id",
-			"CF-Access-Client-Secret": "test-client-secret",
-			"Custom-Header":           "test-value",
-		}
-
-		if len(headers) != len(expectedHeaders) {
-			t.Errorf("Expected %d headers, got %d", len(expectedHeaders), len(headers))
-		}
-
-		for key, expectedValue := range expectedHeaders {
-			if actualValue, exists := headers[key]; !exists {
-				t.Errorf("Expected header %s to exist", key)
-			} else if actualValue != expectedValue {
-				t.Errorf("Expected header %s to have value %s, got %s", key, expectedValue, actualValue)
-			}
-		}
-	})
-
-	// Test case 11: Empty custom headers
-	t.Run("Empty custom headers", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_HEADERS", "")
-
-		// Initialize config
-		cfg, err := InitConfig()
-
-		// Check for errors
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		// Check custom headers
-		headers := cfg.CustomHeaders()
-		if len(headers) != 0 {
-			t.Errorf("Expected 0 headers, got %d", len(headers))
-		}
-	})
-
-	// Test case 12: Invalid header format (should be ignored)
-	t.Run("Invalid header format", func(t *testing.T) {
-		// Set environment variables
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_HEADERS", "invalid-header,valid-header=value,another-invalid")
-
-		// Initialize config
-		cfg, err := InitConfig()
-
-		// Check for errors
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		// Check custom headers (only valid ones should be parsed)
-		headers := cfg.CustomHeaders()
-		expectedHeaders := map[string]string{
-			"valid-header": "value",
-		}
-
-		if len(headers) != len(expectedHeaders) {
-			t.Errorf("Expected %d headers, got %d", len(expectedHeaders), len(headers))
-		}
-
-		for key, expectedValue := range expectedHeaders {
-			if actualValue, exists := headers[key]; !exists {
-				t.Errorf("Expected header %s to exist", key)
-			} else if actualValue != expectedValue {
-				t.Errorf("Expected header %s to have value %s, got %s", key, expectedValue, actualValue)
-			}
-		}
-	})
-
-	t.Run("Default tenant ID in cluster mode", func(t *testing.T) {
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "cluster")
-		os.Setenv("VM_DEFAULT_TENANT_ID", "100:200")
-
-		cfg, err := InitConfig()
-
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		if cfg.DefaultTenantID() != "100:200" {
-			t.Errorf("Expected default tenant ID '100:200', got: %s", cfg.DefaultTenantID())
-		}
-	})
-
-	t.Run("Empty default tenant ID (used default 0)", func(t *testing.T) {
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", "http://example.com")
-		os.Setenv("VM_INSTANCE_TYPE", "cluster")
-		os.Setenv("VM_DEFAULT_TENANT_ID", "")
-
-		cfg, err := InitConfig()
-
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		if cfg.DefaultTenantID() == "" {
-			t.Errorf("Expected no default tenant ID, got: %s", cfg.DefaultTenantID())
-		}
-	})
-}
+	})}

--- a/cmd/mcp-victoriametrics/hooks/hooks.go
+++ b/cmd/mcp-victoriametrics/hooks/hooks.go
@@ -35,11 +35,15 @@ func New(ms *metrics.Set) *server.Hooks {
 		ms.GetOrCreateCounter(`mcp_victoriametrics_list_prompts_total`).Inc()
 	})
 
-	hooks.AddAfterCallTool(func(_ context.Context, _ any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
+	hooks.AddAfterCallTool(func(_ context.Context, _ any, message *mcp.CallToolRequest, resultAny any) {
+		isError := false
+		if res, ok := resultAny.(*mcp.CallToolResult); ok {
+			isError = res.IsError
+		}
 		ms.GetOrCreateCounter(fmt.Sprintf(
 			`mcp_victoriametrics_call_tool_total{name="%s",is_error="%t"}`,
 			message.Params.Name,
-			result.IsError,
+			isError,
 		)).Inc()
 	})
 
@@ -124,11 +128,15 @@ func NewLoggerHooks() *server.Hooks {
 		)
 	})
 
-	hooks.AddAfterCallTool(func(_ context.Context, id any, msg *mcp.CallToolRequest, result *mcp.CallToolResult) {
+	hooks.AddAfterCallTool(func(_ context.Context, id any, msg *mcp.CallToolRequest, resultAny any) {
+		isError := false
+		if res, ok := resultAny.(*mcp.CallToolResult); ok {
+			isError = res.IsError
+		}
 		slog.Info("Tool called",
 			"request_id", id,
 			"tool_name", msg.Params.Name,
-			"is_error", result.IsError,
+			"is_error", isError,
 		)
 	})
 

--- a/cmd/mcp-victoriametrics/main.go
+++ b/cmd/mcp-victoriametrics/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -66,16 +67,7 @@ func main() {
 	loggingHooks := hooks.NewLoggerHooks()
 	combinedHooks := hooks.Merge(metricsHooks, loggingHooks)
 
-	s := server.NewMCPServer(
-		"VictoriaMetrics",
-		fmt.Sprintf("v%s (date: %s)", version, date),
-		server.WithRecovery(),
-		server.WithLogging(),
-		server.WithToolCapabilities(false),
-		server.WithResourceCapabilities(false, false),
-		server.WithPromptCapabilities(false),
-		server.WithHooks(combinedHooks),
-		server.WithInstructions(`
+	instructions := `
 You are Virtual Assistant, a tool for interacting with VictoriaMetrics API and documentation in different tasks related to monitoring and observability.
 
 You have the full documentation about VictoriaMetrics products in your resources, you have to try to use documentation in your answer.
@@ -85,7 +77,21 @@ Use Documentation tool to get the most relevant documents for your task every ti
 You have many tools to get data from VictoriaMetrics, but try to specify the query as accurately as possible, reducing the resulting sample, as some queries can be query heavy.
 
 Try not to second guess information - if you don't know something or lack information, it's better to ask.
-	`),
+	`
+	if envs := c.EnvironmentNames(); len(envs) > 1 {
+		instructions += fmt.Sprintf("\nThis server is configured with multiple VictoriaMetrics environments: %s. Use the optional `env` argument on API tools to target a specific environment. If `env` is omitted, the default environment `%s` is used.\n", strings.Join(envs, ", "), c.DefaultEnvironment())
+	}
+
+	s := server.NewMCPServer(
+		"VictoriaMetrics",
+		fmt.Sprintf("v%s (date: %s)", version, date),
+		server.WithRecovery(),
+		server.WithLogging(),
+		server.WithToolCapabilities(false),
+		server.WithResourceCapabilities(false, false),
+		server.WithPromptCapabilities(false),
+		server.WithHooks(combinedHooks),
+		server.WithInstructions(instructions),
 	)
 
 	// Registering resources

--- a/cmd/mcp-victoriametrics/tools/access_tokens.go
+++ b/cmd/mcp-victoriametrics/tools/access_tokens.go
@@ -32,10 +32,16 @@ func toolAccessTokens(_ *config.Config) mcp.Tool {
 			mcp.Pattern(`^[a-zA-Z0-9\-_]+$`),
 		),
 	)
-	return mcp.NewTool(toolNameAccessTokens, options...)
+	return mcp.NewTool(toolNameAccessTokens, append(options, withEnvironmentParam())...)
 }
 
 func toolAccessTokensHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", true)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get deployment_id parameter: %v", err)), nil
@@ -43,7 +49,7 @@ func toolAccessTokensHandler(ctx context.Context, cfg *config.Config, tcr mcp.Ca
 	if deploymentID == "" {
 		return mcp.NewToolResultError("deployment_id parameter is required for cloud mode"), nil
 	}
-	accessTokens, err := cfg.VMC().ListDeploymentAccessTokens(ctx, deploymentID)
+	accessTokens, err := env.VMC().ListDeploymentAccessTokens(ctx, deploymentID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list access_tokens: %v", err)), nil
 	}

--- a/cmd/mcp-victoriametrics/tools/active_queries.go
+++ b/cmd/mcp-victoriametrics/tools/active_queries.go
@@ -44,7 +44,7 @@ This information is obtained from the "/api/v1/status/active_queries" HTTP endpo
 			),
 		)
 	}
-	return mcp.NewTool(toolNameActiveQueries, options...)
+	return mcp.NewTool(toolNameActiveQueries, append(options, withEnvironmentParam())...)
 }
 
 func toolActiveQueriesHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/alerts.go
+++ b/cmd/mcp-victoriametrics/tools/alerts.go
@@ -71,7 +71,7 @@ func toolAlerts(c *config.Config) mcp.Tool {
 			mcp.DefaultNumber(0),
 		),
 	)
-	return mcp.NewTool(toolNameAlerts, options...)
+	return mcp.NewTool(toolNameAlerts, append(options, withEnvironmentParam())...)
 }
 
 func toolAlertsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/cloud_providers.go
+++ b/cmd/mcp-victoriametrics/tools/cloud_providers.go
@@ -23,11 +23,17 @@ func toolCloudProviders(_ *config.Config) mcp.Tool {
 			OpenWorldHint:   ptr(true),
 		}),
 	}
-	return mcp.NewTool(toolNameCloudProviders, options...)
+	return mcp.NewTool(toolNameCloudProviders, append(options, withEnvironmentParam())...)
 }
 
-func toolCloudProvidersHandler(ctx context.Context, cfg *config.Config, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	cloudProviders, err := cfg.VMC().ListCloudProviders(ctx)
+func toolCloudProvidersHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	cloudProviders, err := env.VMC().ListCloudProviders(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list cloud providers: %v", err)), nil
 	}

--- a/cmd/mcp-victoriametrics/tools/deployments.go
+++ b/cmd/mcp-victoriametrics/tools/deployments.go
@@ -23,11 +23,17 @@ func toolDeployments(_ *config.Config) mcp.Tool {
 			OpenWorldHint:   ptr(true),
 		}),
 	}
-	return mcp.NewTool(toolNameDeployments, options...)
+	return mcp.NewTool(toolNameDeployments, append(options, withEnvironmentParam())...)
 }
 
-func toolDeploymentsHandler(ctx context.Context, cfg *config.Config, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	deployments, err := cfg.VMC().ListDeployments(ctx)
+func toolDeploymentsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	deployments, err := env.VMC().ListDeployments(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list deployments: %v", err)), nil
 	}

--- a/cmd/mcp-victoriametrics/tools/downsampling_filters_debug.go
+++ b/cmd/mcp-victoriametrics/tools/downsampling_filters_debug.go
@@ -48,7 +48,7 @@ This tool use "/downsampling-filters-debug" API endpoint of VictoriaMetrics API.
 			mcp.Pattern(`^([a-zA-Z_]*\{\s*(([a-zA-Z-_]+\s*\=\s*\".*\"))?(\s*,\s*([a-zA-Z-_]+\s*\=\s*\".*\"))*\s*\}\n)+$`),
 		),
 	)
-	return mcp.NewTool(toolNameDownsamplingFiltersDebug, options...)
+	return mcp.NewTool(toolNameDownsamplingFiltersDebug, append(options, withEnvironmentParam())...)
 }
 
 func toolDownsamplingFiltersDebugHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/explain_query.go
+++ b/cmd/mcp-victoriametrics/tools/explain_query.go
@@ -30,6 +30,7 @@ var (
 			DestructiveHint: ptr(false),
 			OpenWorldHint:   ptr(false),
 		}),
+		withEnvironmentParam(),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Title("MetricsQL or PromQL expression"),
@@ -39,12 +40,17 @@ var (
 )
 
 func toolExplainQueryHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 	query, err := GetToolReqParam[string](tcr, "query", true)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	info, err := getQueryInfo(ctx, cfg, tcr, query)
+	info, err := getQueryInfo(ctx, cfg, tcr, env, query)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("error explaining query: %s", err)), nil
 	}
@@ -72,7 +78,7 @@ func RegisterToolExplainQuery(s *server.MCPServer, c *config.Config) {
 	})
 }
 
-func getQueryInfo(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, query string) (map[string]any, error) {
+func getQueryInfo(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, env *config.InstanceConfig, query string) (map[string]any, error) {
 	expr, err := metricsql.Parse(query)
 	if err != nil {
 		return nil, fmt.Errorf("query parsing error: %w", err)
@@ -85,7 +91,7 @@ func getQueryInfo(ctx context.Context, cfg *config.Config, tcr mcp.CallToolReque
 		"syntax_tree":    st,
 		"types_info":     getTypesDescriptions(types),
 		"functions_info": getFunctionsInfo(functions),
-		"metrics_info":   getMetricsInfo(ctx, cfg, tcr, metrics),
+		"metrics_info":   getMetricsInfo(ctx, cfg, tcr, env, metrics),
 	}
 	return result, nil
 }
@@ -129,13 +135,13 @@ var metricsMetadataDBDir embed.FS
 var metricsInfo map[string]any
 
 // fetchMetricsMetadataFromAPI fetches metrics metadata from VictoriaMetrics API
-func fetchMetricsMetadataFromAPI(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, metricNames []string) (map[string]metricInfo, error) {
+func fetchMetricsMetadataFromAPI(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, env *config.InstanceConfig, metricNames []string) (map[string]metricInfo, error) {
 	if len(metricNames) == 0 {
 		return make(map[string]metricInfo), nil
 	}
 
 	// Skip API fetch if config is not properly initialized
-	if cfg == nil || (cfg.EntryPointURL() == nil && !cfg.IsCloud()) {
+	if env == nil || (env.EntryPointURL() == nil && !env.IsCloud()) {
 		return make(map[string]metricInfo), nil
 	}
 
@@ -195,17 +201,17 @@ func fetchMetricsMetadataFromAPI(ctx context.Context, cfg *config.Config, tcr mc
 	return result, nil
 }
 
-func getMetricsInfo(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, metrics map[string]struct{}) map[string]metricInfo {
+func getMetricsInfo(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, env *config.InstanceConfig, metrics map[string]struct{}) map[string]metricInfo {
 	result := make(map[string]metricInfo)
 
 	// First, try to fetch metadata from API if config is available
-	if cfg != nil {
+	if env != nil {
 		metricNames := make([]string, 0, len(metrics))
 		for metric := range metrics {
 			metricNames = append(metricNames, metric)
 		}
 
-		apiMetadata, err := fetchMetricsMetadataFromAPI(ctx, cfg, tcr, metricNames)
+		apiMetadata, err := fetchMetricsMetadataFromAPI(ctx, cfg, tcr, env, metricNames)
 		if err == nil && len(apiMetadata) > 0 {
 			// Use API metadata
 			for metric, info := range apiMetadata {

--- a/cmd/mcp-victoriametrics/tools/explain_query_test.go
+++ b/cmd/mcp-victoriametrics/tools/explain_query_test.go
@@ -203,8 +203,9 @@ func TestGetQueryInfo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			env, _ := cfg.Environment("")
 			// Call the function
-			info, err := getQueryInfo(context.Background(), cfg, tcr, tc.query)
+			info, err := getQueryInfo(context.Background(), cfg, tcr, env, tc.query)
 
 			// Check for errors
 			if tc.expectError {

--- a/cmd/mcp-victoriametrics/tools/export.go
+++ b/cmd/mcp-victoriametrics/tools/export.go
@@ -72,7 +72,7 @@ func toolExport(c *config.Config) mcp.Tool {
 		),
 	)
 
-	return mcp.NewTool(toolNameExport, options...)
+	return mcp.NewTool(toolNameExport, append(options, withEnvironmentParam())...)
 }
 
 func toolExportHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/flags.go
+++ b/cmd/mcp-victoriametrics/tools/flags.go
@@ -35,11 +35,17 @@ func toolFlags(c *config.Config) mcp.Tool {
 			),
 		)
 	}
-	return mcp.NewTool(toolNameFlags, options...)
+	return mcp.NewTool(toolNameFlags, append(options, withEnvironmentParam())...)
 }
 
 func toolFlagsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	if cfg.IsCloud() {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if env.IsCloud() {
 		deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", true)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to get deployment_id parameter: %v", err)), nil
@@ -47,7 +53,7 @@ func toolFlagsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolR
 		if deploymentID == "" {
 			return mcp.NewToolResultError("deployment_id parameter is required for cloud mode"), nil
 		}
-		dd, err := cfg.VMC().GetDeploymentDetails(ctx, deploymentID)
+		dd, err := env.VMC().GetDeploymentDetails(ctx, deploymentID)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to get deployment details: %v", err)), nil
 		}

--- a/cmd/mcp-victoriametrics/tools/labels.go
+++ b/cmd/mcp-victoriametrics/tools/labels.go
@@ -70,7 +70,7 @@ func toolLabels(c *config.Config) mcp.Tool {
 			mcp.Min(0),
 		),
 	)
-	return mcp.NewTool(toolNameLabels, options...)
+	return mcp.NewTool(toolNameLabels, append(options, withEnvironmentParam())...)
 }
 
 func toolLabelsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/labelvalues.go
+++ b/cmd/mcp-victoriametrics/tools/labelvalues.go
@@ -76,7 +76,7 @@ func toolLabelsValues(c *config.Config) mcp.Tool {
 			mcp.Min(0),
 		),
 	)
-	return mcp.NewTool(toolNameLabelValues, options...)
+	return mcp.NewTool(toolNameLabelValues, append(options, withEnvironmentParam())...)
 }
 
 func toolLabelValuesHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/metric_relabel_debug.go
+++ b/cmd/mcp-victoriametrics/tools/metric_relabel_debug.go
@@ -48,7 +48,7 @@ The tool use "/metric-relabel-debug" endpoint of the VictoriaMetrics API. `),
 			mcp.Pattern(`^\{\s*(([a-zA-Z-_]+\s*\=\s*\".*\"))?(\s*,\s*([a-zA-Z-_]+\s*\=\s*\".*\"))*\s*\}$`),
 		),
 	)
-	return mcp.NewTool(toolNameMetricRelabelDebug, options...)
+	return mcp.NewTool(toolNameMetricRelabelDebug, append(options, withEnvironmentParam())...)
 }
 
 func toolMetricRelabelDebugHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/metrics.go
+++ b/cmd/mcp-victoriametrics/tools/metrics.go
@@ -69,7 +69,7 @@ func toolMetrics(c *config.Config) mcp.Tool {
 			mcp.Min(0),
 		),
 	)
-	return mcp.NewTool(toolNameMetrics, options...)
+	return mcp.NewTool(toolNameMetrics, append(options, withEnvironmentParam())...)
 }
 
 func toolMetricsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/metrics_metadata.go
+++ b/cmd/mcp-victoriametrics/tools/metrics_metadata.go
@@ -75,7 +75,7 @@ func toolMetricsMetadata(c *config.Config) mcp.Tool {
 			mcp.Min(0),
 		),
 	)
-	return mcp.NewTool(toolNameMetricsMetadata, options...)
+	return mcp.NewTool(toolNameMetricsMetadata, append(options, withEnvironmentParam())...)
 }
 
 func toolMetricsMetadataHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/metricstats.go
+++ b/cmd/mcp-victoriametrics/tools/metricstats.go
@@ -61,7 +61,7 @@ func toolMetricStats(c *config.Config) mcp.Tool {
 			mcp.Description("less than or equal, is an integer threshold for filtering metric names by their usage count in queries. For example, with ?le=1 API returns metric names that were queried <=1 times."),
 		),
 	)
-	return mcp.NewTool(toolNameMetricStats, options...)
+	return mcp.NewTool(toolNameMetricStats, append(options, withEnvironmentParam())...)
 }
 
 func toolMetricStatsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/prettify_query.go
+++ b/cmd/mcp-victoriametrics/tools/prettify_query.go
@@ -52,10 +52,16 @@ func toolPrettifyQuery(c *config.Config) mcp.Tool {
 			mcp.Description(`MetricsQL or PromQL expression for prettification. This is the query that will be formatted.`),
 		),
 	)
-	return mcp.NewTool(toolNamePrettifyQuery, options...)
+	return mcp.NewTool(toolNamePrettifyQuery, append(options, withEnvironmentParam())...)
 }
 
 func toolPrettifyQueryHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	query, err := GetToolReqParam[string](tcr, "query", true)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -72,7 +78,7 @@ func toolPrettifyQueryHandler(ctx context.Context, cfg *config.Config, tcr mcp.C
 			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
 		}
 		return mcp.NewToolResultText(string(data)), nil
-	} else if cfg.IsCloud() {
+	} else if env.IsCloud() {
 		deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", false)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to get deployment_id parameter: %v", err)), nil

--- a/cmd/mcp-victoriametrics/tools/query.go
+++ b/cmd/mcp-victoriametrics/tools/query.go
@@ -76,7 +76,7 @@ func toolQuery(c *config.Config) mcp.Tool {
 			mcp.DefaultBool(false),
 		),
 	)
-	return mcp.NewTool(toolNameQuery, options...)
+	return mcp.NewTool(toolNameQuery, append(options, withEnvironmentParam())...)
 }
 
 func toolQueryHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/query_range.go
+++ b/cmd/mcp-victoriametrics/tools/query_range.go
@@ -82,7 +82,7 @@ func toolQueryRange(c *config.Config) mcp.Tool {
 			mcp.DefaultBool(false),
 		),
 	)
-	return mcp.NewTool(toolNameQueryRange, options...)
+	return mcp.NewTool(toolNameQueryRange, append(options, withEnvironmentParam())...)
 }
 
 func toolQueryRangeHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/regions.go
+++ b/cmd/mcp-victoriametrics/tools/regions.go
@@ -23,11 +23,17 @@ func toolRegions(_ *config.Config) mcp.Tool {
 			OpenWorldHint:   ptr(true),
 		}),
 	}
-	return mcp.NewTool(toolNameRegions, options...)
+	return mcp.NewTool(toolNameRegions, append(options, withEnvironmentParam())...)
 }
 
-func toolRegionsHandler(ctx context.Context, cfg *config.Config, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	regions, err := cfg.VMC().ListRegions(ctx)
+func toolRegionsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	regions, err := env.VMC().ListRegions(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list regions: %v", err)), nil
 	}

--- a/cmd/mcp-victoriametrics/tools/retention_filters_debug.go
+++ b/cmd/mcp-victoriametrics/tools/retention_filters_debug.go
@@ -47,7 +47,7 @@ This tool use "/retention-filters-debug" API endpoint of VictoriaMetrics API.`),
 			mcp.Pattern(`^([a-zA-Z_]*\{\s*(([a-zA-Z-_]+\s*\=\s*\".*\"))?(\s*,\s*([a-zA-Z-_]+\s*\=\s*\".*\"))*\s*\}\n)+$`),
 		),
 	)
-	return mcp.NewTool(toolNameRetentionFiltersDebug, options...)
+	return mcp.NewTool(toolNameRetentionFiltersDebug, append(options, withEnvironmentParam())...)
 }
 
 func toolRetentionFiltersDebugHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/rule_file.go
+++ b/cmd/mcp-victoriametrics/tools/rule_file.go
@@ -42,10 +42,16 @@ func toolRuleFile(_ *config.Config) mcp.Tool {
 			mcp.Max(255),
 		),
 	)
-	return mcp.NewTool(toolNameRuleFile, options...)
+	return mcp.NewTool(toolNameRuleFile, append(options, withEnvironmentParam())...)
 }
 
 func toolRuleFileHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", true)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get deployment_id parameter: %v", err)), nil
@@ -59,7 +65,7 @@ func toolRuleFileHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallTo
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get rules_filename parameter: %v", err)), nil
 	}
 
-	ruleFilenames, err := cfg.VMC().GetDeploymentRuleFileContent(ctx, deploymentID, filename)
+	ruleFilenames, err := env.VMC().GetDeploymentRuleFileContent(ctx, deploymentID, filename)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list of rule filenames: %v", err)), nil
 	}

--- a/cmd/mcp-victoriametrics/tools/rule_filenames.go
+++ b/cmd/mcp-victoriametrics/tools/rule_filenames.go
@@ -32,10 +32,16 @@ func toolRuleFilenames(_ *config.Config) mcp.Tool {
 			mcp.Pattern(`^[a-zA-Z0-9\-_]+$`),
 		),
 	)
-	return mcp.NewTool(toolNameRuleFilenames, options...)
+	return mcp.NewTool(toolNameRuleFilenames, append(options, withEnvironmentParam())...)
 }
 
 func toolRuleFilenamesHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", true)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get deployment_id parameter: %v", err)), nil
@@ -43,7 +49,7 @@ func toolRuleFilenamesHandler(ctx context.Context, cfg *config.Config, tcr mcp.C
 	if deploymentID == "" {
 		return mcp.NewToolResultError("deployment_id parameter is required for cloud mode"), nil
 	}
-	ruleFilenames, err := cfg.VMC().ListDeploymentRuleFileNames(ctx, deploymentID)
+	ruleFilenames, err := env.VMC().ListDeploymentRuleFileNames(ctx, deploymentID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list of rule filenames: %v", err)), nil
 	}

--- a/cmd/mcp-victoriametrics/tools/rules.go
+++ b/cmd/mcp-victoriametrics/tools/rules.go
@@ -78,7 +78,7 @@ func toolRules(c *config.Config) mcp.Tool {
 			mcp.Items(map[string]any{"type": "string"}),
 		),
 	)
-	return mcp.NewTool(toolNameRules, options...)
+	return mcp.NewTool(toolNameRules, append(options, withEnvironmentParam())...)
 }
 
 func toolRulesHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/series.go
+++ b/cmd/mcp-victoriametrics/tools/series.go
@@ -69,7 +69,7 @@ func toolSeries(c *config.Config) mcp.Tool {
 			mcp.Min(0),
 		),
 	)
-	return mcp.NewTool(toolNameSeries, options...)
+	return mcp.NewTool(toolNameSeries, append(options, withEnvironmentParam())...)
 }
 
 func toolSeriesHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/tenants.go
+++ b/cmd/mcp-victoriametrics/tools/tenants.go
@@ -32,7 +32,7 @@ func toolTenants(c *config.Config) mcp.Tool {
 			),
 		)
 	}
-	return mcp.NewTool(toolNameTenants, options...)
+	return mcp.NewTool(toolNameTenants, append(options, withEnvironmentParam())...)
 }
 
 func toolTenantsHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/tiers.go
+++ b/cmd/mcp-victoriametrics/tools/tiers.go
@@ -23,11 +23,17 @@ func toolTiers(_ *config.Config) mcp.Tool {
 			OpenWorldHint:   ptr(true),
 		}),
 	}
-	return mcp.NewTool(toolNameTiers, options...)
+	return mcp.NewTool(toolNameTiers, append(options, withEnvironmentParam())...)
 }
 
-func toolTiersHandler(ctx context.Context, cfg *config.Config, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	tiers, err := cfg.VMC().ListTiers(ctx)
+func toolTiersHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envName, _ := GetToolReqParam[string](tcr, "env", false)
+	env, err := cfg.Environment(envName)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	tiers, err := env.VMC().ListTiers(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list tiers: %v", err)), nil
 	}

--- a/cmd/mcp-victoriametrics/tools/top_queries.go
+++ b/cmd/mcp-victoriametrics/tools/top_queries.go
@@ -66,7 +66,7 @@ This information is obtained from the "/api/v1/status/top_queries" HTTP endpoint
 			mcp.Pattern(`^([0-9]+)([a-z]+)$`),
 		),
 	)
-	return mcp.NewTool(toolNameTopQueries, options...)
+	return mcp.NewTool(toolNameTopQueries, append(options, withEnvironmentParam())...)
 }
 
 func toolTopQueriesHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/tsdb_status.go
+++ b/cmd/mcp-victoriametrics/tools/tsdb_status.go
@@ -82,7 +82,7 @@ This tool returns TSDB stats from "/api/v1/status/tsdb" endpoint of VictoriaMetr
 			mcp.DefaultString(""),
 		),
 	)
-	return mcp.NewTool(toolNameTSDBStatus, options...)
+	return mcp.NewTool(toolNameTSDBStatus, append(options, withEnvironmentParam())...)
 }
 
 func toolTSDBStatusHandler(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cmd/mcp-victoriametrics/tools/utils.go
+++ b/cmd/mcp-victoriametrics/tools/utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -16,7 +17,12 @@ import (
 )
 
 func CreateSelectRequest(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, path ...string) (*http.Request, error) {
-	selectURL, err := getSelectURL(ctx, cfg, tcr, path...)
+	environment, err := getToolEnvironment(cfg, tcr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve env: %v", err)
+	}
+
+	selectURL, err := getSelectURL(ctx, environment, tcr, path...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get select URL: %v", err)
 	}
@@ -25,14 +31,16 @@ func CreateSelectRequest(ctx context.Context, cfg *config.Config, tcr mcp.CallTo
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
-	bearerToken, err := getBearerToken(ctx, cfg, tcr)
+	bearerToken, err := getBearerToken(ctx, environment, tcr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get bearer token: %v", err)
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
+	if bearerToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
+	}
 
 	// Add custom headers from configuration
-	for key, value := range cfg.CustomHeaders() {
+	for key, value := range environment.CustomHeaders() {
 		req.Header.Set(key, value)
 	}
 
@@ -40,7 +48,12 @@ func CreateSelectRequest(ctx context.Context, cfg *config.Config, tcr mcp.CallTo
 }
 
 func CreateAdminRequest(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, path ...string) (*http.Request, error) {
-	selectURL, err := getRootURL(ctx, cfg, tcr, path...)
+	environment, err := getToolEnvironment(cfg, tcr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve env: %v", err)
+	}
+
+	selectURL, err := getRootURL(ctx, environment, tcr, path...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get select URL: %v", err)
 	}
@@ -49,14 +62,16 @@ func CreateAdminRequest(ctx context.Context, cfg *config.Config, tcr mcp.CallToo
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
-	bearerToken, err := getBearerToken(ctx, cfg, tcr)
+	bearerToken, err := getBearerToken(ctx, environment, tcr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get bearer token: %v", err)
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
+	if bearerToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
+	}
 
 	// Add custom headers from configuration
-	for key, value := range cfg.CustomHeaders() {
+	for key, value := range environment.CustomHeaders() {
 		req.Header.Set(key, value)
 	}
 
@@ -75,7 +90,7 @@ var (
 	cloudDeploymentInfoCache      = make(map[string]cloudDeploymentInfo)
 )
 
-func getCloudDeploymentInfo(ctx context.Context, cfg *config.Config, deploymentID string) (cloudDeploymentInfo, error) {
+func getCloudDeploymentInfo(ctx context.Context, environment *config.InstanceConfig, deploymentID string) (cloudDeploymentInfo, error) {
 	cloudDeploymentInfoCacheMutex.RLock()
 	info, ok := cloudDeploymentInfoCache[deploymentID]
 	cloudDeploymentInfoCacheMutex.RUnlock()
@@ -83,7 +98,7 @@ func getCloudDeploymentInfo(ctx context.Context, cfg *config.Config, deploymentI
 		return info, nil
 	}
 
-	dd, err := cfg.VMC().GetDeploymentDetails(ctx, deploymentID)
+	dd, err := environment.VMC().GetDeploymentDetails(ctx, deploymentID)
 	if err != nil {
 		return cloudDeploymentInfo{}, fmt.Errorf("failed to get deployment details: %v", err)
 	}
@@ -104,9 +119,9 @@ func getCloudDeploymentInfo(ctx context.Context, cfg *config.Config, deploymentI
 	return info, nil
 }
 
-func getBearerToken(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest) (string, error) {
-	if !cfg.IsCloud() {
-		return cfg.BearerToken(), nil
+func getBearerToken(ctx context.Context, environment *config.InstanceConfig, tcr mcp.CallToolRequest) (string, error) {
+	if !environment.IsCloud() {
+		return environment.BearerToken(), nil
 	}
 
 	deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", true)
@@ -124,7 +139,7 @@ func getBearerToken(ctx context.Context, cfg *config.Config, tcr mcp.CallToolReq
 	}
 	cloudAccessTokenCacheMutex.RUnlock()
 
-	at, err := cfg.VMC().ListDeploymentAccessTokens(ctx, deploymentID)
+	at, err := environment.VMC().ListDeploymentAccessTokens(ctx, deploymentID)
 	if err != nil {
 		return "", fmt.Errorf("failed to list deployment access tokens: %v", err)
 	}
@@ -138,7 +153,7 @@ func getBearerToken(ctx context.Context, cfg *config.Config, tcr mcp.CallToolReq
 		if t.TenantID != "" {
 			continue // Skip tokens with specific tenant ID
 		}
-		token, err := cfg.VMC().RevealDeploymentAccessToken(ctx, deploymentID, t.ID)
+		token, err := environment.VMC().RevealDeploymentAccessToken(ctx, deploymentID, t.ID)
 		if err != nil {
 			return "", fmt.Errorf("failed to reveal access token for deployment %s: %v", deploymentID, err)
 		}
@@ -151,17 +166,17 @@ func getBearerToken(ctx context.Context, cfg *config.Config, tcr mcp.CallToolReq
 	return result, fmt.Errorf("no read access tokens found for deployment %s", deploymentID)
 }
 
-func getRootURL(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, path ...string) (string, error) {
-	entrypointURL := cfg.EntryPointURL()
-	if cfg.IsCloud() {
-		deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", cfg.IsCloud())
+func getRootURL(ctx context.Context, environment *config.InstanceConfig, tcr mcp.CallToolRequest, path ...string) (string, error) {
+	entrypointURL := environment.EntryPointURL()
+	if environment.IsCloud() {
+		deploymentID, err := GetToolReqParam[string](tcr, "deployment_id", true)
 		if err != nil {
 			return "", fmt.Errorf("failed to get deployment_id parameter: %v", err)
 		}
 		if deploymentID == "" {
 			return "", fmt.Errorf("deployment_id parameter is required for cloud mode")
 		}
-		info, err := getCloudDeploymentInfo(ctx, cfg, deploymentID)
+		info, err := getCloudDeploymentInfo(ctx, environment, deploymentID)
 		if err != nil {
 			return "", fmt.Errorf("failed to get cloud deployment info: %v", err)
 		}
@@ -173,22 +188,22 @@ func getRootURL(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest
 	return entrypointURL.JoinPath(path...).String(), nil
 }
 
-func getSelectURL(ctx context.Context, cfg *config.Config, tcr mcp.CallToolRequest, path ...string) (string, error) {
+func getSelectURL(ctx context.Context, environment *config.InstanceConfig, tcr mcp.CallToolRequest, path ...string) (string, error) {
 	var err error
 	deploymentID := ""
-	entrypointURL := cfg.EntryPointURL()
-	isSingle := cfg.IsSingle()
+	entrypointURL := environment.EntryPointURL()
+	isSingle := environment.IsSingle()
 
 	// Cloud mode
-	if cfg.IsCloud() {
-		deploymentID, err = GetToolReqParam[string](tcr, "deployment_id", cfg.IsCloud())
+	if environment.IsCloud() {
+		deploymentID, err = GetToolReqParam[string](tcr, "deployment_id", true)
 		if err != nil {
 			return "", fmt.Errorf("failed to get deployment_id parameter: %v", err)
 		}
 		if deploymentID == "" {
 			return "", fmt.Errorf("deployment_id parameter is required for cloud mode")
 		}
-		info, err := getCloudDeploymentInfo(ctx, cfg, deploymentID)
+		info, err := getCloudDeploymentInfo(ctx, environment, deploymentID)
 		if err != nil {
 			return "", fmt.Errorf("failed to get cloud deployment info: %v", err)
 		}
@@ -210,7 +225,7 @@ func getSelectURL(ctx context.Context, cfg *config.Config, tcr mcp.CallToolReque
 		return "", fmt.Errorf("failed to get tenant parameter: %v", err)
 	}
 	if tenant == "" {
-		tenant = cfg.DefaultTenantID()
+		tenant = environment.DefaultTenantID()
 	}
 	args := []string{"select", tenant, "prometheus"}
 	return entrypointURL.JoinPath(append(args, path...)...).String(), nil
@@ -254,6 +269,38 @@ func GetToolReqParam[T ToolReqParamType](tcr mcp.CallToolRequest, param string, 
 		return value, fmt.Errorf("%s param is required", param)
 	}
 	return value, nil
+}
+
+func GetToolReqEnv(tcr mcp.CallToolRequest) (string, error) {
+	env, err := GetToolReqParam[string](tcr, "env", false)
+	if err != nil {
+		return "", fmt.Errorf("failed to get env: %v", err)
+	}
+	if env != "" {
+		return strings.ToLower(strings.TrimSpace(env)), nil
+	}
+
+	environment, err := GetToolReqParam[string](tcr, "environment", false)
+	if err != nil {
+		return "", fmt.Errorf("failed to get environment: %v", err)
+	}
+	return strings.ToLower(strings.TrimSpace(environment)), nil
+}
+
+func getToolEnvironment(cfg *config.Config, tcr mcp.CallToolRequest) (*config.InstanceConfig, error) {
+	envName, err := GetToolReqEnv(tcr)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Environment(envName)
+}
+
+func withEnvironmentParam() mcp.ToolOption {
+	return mcp.WithString("env",
+		mcp.Title("Environment"),
+		mcp.Description("Optional VictoriaMetrics environment to target. If omitted, the server default environment is used."),
+		mcp.Pattern(`^[A-Za-z0-9_-]+$`),
+	)
 }
 
 func ptr[T any](v T) *T {

--- a/cmd/mcp-victoriametrics/tools/utils_test.go
+++ b/cmd/mcp-victoriametrics/tools/utils_test.go
@@ -235,15 +235,11 @@ func TestGetToolReqParamStringSlice(t *testing.T) {
 
 // TestGetSelectURLWithDefaultTenant tests that getSelectURL uses default tenant from config
 func TestGetSelectURLWithDefaultTenant(t *testing.T) {
-	originalEntrypoint := os.Getenv("VM_INSTANCE_ENTRYPOINT")
-	originalInstanceType := os.Getenv("VM_INSTANCE_TYPE")
-	originalDefaultTenantID := os.Getenv("VM_DEFAULT_TENANT_ID")
-
-	defer func() {
-		os.Setenv("VM_INSTANCE_ENTRYPOINT", originalEntrypoint)
-		os.Setenv("VM_INSTANCE_TYPE", originalInstanceType)
-		os.Setenv("VM_DEFAULT_TENANT_ID", originalDefaultTenantID)
-	}()
+	// Clear env for clean state
+	os.Unsetenv("VM_INSTANCE_ENTRYPOINT")
+	os.Unsetenv("VM_INSTANCE_TYPE")
+	os.Unsetenv("VM_DEFAULT_TENANT_ID")
+	os.Unsetenv("VM_ENVIRONMENTS")
 
 	testCases := []struct {
 		name            string
@@ -313,7 +309,9 @@ func TestGetSelectURLWithDefaultTenant(t *testing.T) {
 				tcr.Params.Arguments = map[string]any{"tenant": tc.requestTenant}
 			}
 
-			url, err := getSelectURL(context.Background(), cfg, tcr, "api", "v1", "query")
+			// Environment lookup in test context
+			env, _ := cfg.Environment("")
+			url, err := getSelectURL(context.Background(), env, tcr, "api", "v1", "query")
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -323,4 +321,69 @@ func TestGetSelectURLWithDefaultTenant(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEnvRouting tests that requests are routed to the correct environment
+func TestEnvRouting(t *testing.T) {
+	// Clear env for clean state
+	os.Unsetenv("VM_INSTANCE_ENTRYPOINT")
+	os.Unsetenv("VM_INSTANCE_TYPE")
+	os.Unsetenv("VM_INSTANCE_BEARER_TOKEN")
+	os.Unsetenv("VM_INSTANCE_HEADERS")
+	os.Unsetenv("VM_DEFAULT_TENANT_ID")
+	os.Unsetenv("VM_INSTANCE_DEFAULT_ENTRYPOINT")
+	os.Unsetenv("VM_INSTANCE_DEFAULT_TYPE")
+	os.Unsetenv("VM_INSTANCE_DEMO_ENTRYPOINT")
+	os.Unsetenv("VM_INSTANCE_DEMO_TYPE")
+	os.Setenv("VM_ENVIRONMENTS", "default,demo")
+	os.Setenv("VM_INSTANCE_DEFAULT_ENTRYPOINT", "http://default.com")
+	os.Setenv("VM_INSTANCE_DEFAULT_TYPE", "single")
+	os.Setenv("VM_INSTANCE_DEMO_ENTRYPOINT", "http://demo.com")
+	os.Setenv("VM_INSTANCE_DEMO_TYPE", "single")
+
+	cfg, err := config.InitConfig()
+	if err != nil {
+		t.Fatalf("Failed to create config: %v", err)
+	}
+
+	t.Run("Route to default environment", func(t *testing.T) {
+		tcr := mcp.CallToolRequest{}
+		tcr.Params.Arguments = map[string]any{"env": "default"}
+
+		env, err := getToolEnvironment(cfg, tcr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		url, _ := getSelectURL(context.Background(), env, tcr, "api", "v1", "query")
+		if url != "http://default.com/api/v1/query" {
+			t.Errorf("Expected default URL, got %q", url)
+		}
+	})
+
+	t.Run("Route to demo environment", func(t *testing.T) {
+		tcr := mcp.CallToolRequest{}
+		tcr.Params.Arguments = map[string]any{"env": "demo"}
+
+		env, err := getToolEnvironment(cfg, tcr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		url, _ := getSelectURL(context.Background(), env, tcr, "api", "v1", "query")
+		if url != "http://demo.com/api/v1/query" {
+			t.Errorf("Expected demo URL, got %q", url)
+		}
+	})
+
+	t.Run("Route to default when env is omitted", func(t *testing.T) {
+		tcr := mcp.CallToolRequest{}
+
+		env, err := getToolEnvironment(cfg, tcr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		url, _ := getSelectURL(context.Background(), env, tcr, "api", "v1", "query")
+		if url != "http://default.com/api/v1/query" {
+			t.Errorf("Expected default URL, got %q", url)
+		}
+	})
 }

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -1,4 +1,6 @@
-{{- $isCloud := gt (len .Values.vm.cloudAPIKey) 0 }}
+{{- if and .Values.vm.entrypoint (osEnv "VM_ENVIRONMENTS") }}
+{{- fail "Cannot set both .Values.vm.entrypoint and VM_ENVIRONMENTS. Please use only one configuration mode." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,14 +44,18 @@ spec:
               value: "0.0.0.0:{{  .Values.service.port }}"
             - name: MCP_SERVER_MODE
               value: "{{ .Values.mcp.mode }}"
-            {{- if $isCloud }}
+            {{- with .Values.vm.cloudAPIKey }}
             - name: VMC_API_KEY
-              value: "{{ .Values.vm.cloudAPIKey }}"
-            {{- else }}
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.vm.entrypoint }}
             - name: VM_INSTANCE_ENTRYPOINT
-              value: "{{ required "either .Values.vm.cloudAPIKey or .Values.vm.entrypoint should be set" .Values.vm.entrypoint }}"
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.vm.type }}
             - name: VM_INSTANCE_TYPE
-              value: "{{ .Values.vm.type }}"
+              value: "{{ . }}"
+            {{- end }}
             {{- with .Values.vm.bearerToken }}
             - name: VM_INSTANCE_BEARER_TOKEN
               {{- if kindIs "map" . }}
@@ -57,7 +63,6 @@ spec:
               {{- else }}
               value: "{{ . }}"
               {{- end }}
-            {{- end }}
             {{- end }}
             {{- with .Values.vm.headers }}
             - name: VM_INSTANCE_HEADERS
@@ -80,7 +85,7 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              container_Port: {{ .Values.service.port }}
               protocol: TCP
           {{- with .Values.livenessProbe }}
           livenessProbe: {{ toYaml . | nindent 12 }}

--- a/server.json
+++ b/server.json
@@ -18,28 +18,84 @@
       "environmentVariables": [
         {
           "name": "VM_INSTANCE_ENTRYPOINT",
-          "description": "URL to VictoriaMetrics instance (it should be root URL of vmsingle or vmselect), for example http://localhost:8428 or https://play.victoriametrics.com",
-          "isRequired": true,
+          "description": "URL to VictoriaMetrics instance (it should be root URL of vmsingle or vmselect). Use this only when VM_ENVIRONMENTS is not set.",
+          "isRequired": false,
           "format": "string",
           "isSecret": false
         },
         {
           "name": "VM_INSTANCE_TYPE",
-          "description": "Type of VictoriaMetrics instance (single / cluster)",
-          "isRequired": true,
+          "description": "Type of VictoriaMetrics instance (single / cluster). Use this only when VM_ENVIRONMENTS is not set.",
+          "isRequired": false,
           "format": "string",
           "isSecret": false
         },
         {
           "name": "VM_INSTANCE_BEARER_TOKEN",
           "description": "Authentication token for VictoriaMetrics API",
-          "isRequired": true,
+          "isRequired": false,
           "format": "string",
           "isSecret": true
         },
         {
           "name": "VMC_API_KEY",
-          "description": "Optional: API key from VictoriaMetrics Cloud Console (if you have deployment in VictoriaMetrics Cloud)",
+          "description": "API key from VictoriaMetrics Cloud Console",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "VM_ENVIRONMENTS",
+          "description": "Comma-separated list of named VictoriaMetrics environments exposed by this MCP server, for example demo,staging,prod",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "VM_DEFAULT_ENVIRONMENT",
+          "description": "Default environment used when a tool call omits env",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "VM_INSTANCE_<ENV>_ENTRYPOINT",
+          "description": "Per-environment VictoriaMetrics entrypoint. Required for every environment listed in VM_ENVIRONMENTS (unless VMC_<ENV>_API_KEY is used).",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "VM_INSTANCE_<ENV>_TYPE",
+          "description": "Per-environment VictoriaMetrics instance type (single / cluster). Required if using ENTRYPOINT.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "VM_INSTANCE_<ENV>_BEARER_TOKEN",
+          "description": "Per-environment bearer token for VictoriaMetrics API",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "VM_INSTANCE_<ENV>_HEADERS",
+          "description": "Per-environment custom headers as comma-separated key=value pairs",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "VM_INSTANCE_<ENV>_DEFAULT_TENANT_ID",
+          "description": "Per-environment default tenant ID",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "VMC_<ENV>_API_KEY",
+          "description": "Per-environment API key from VictoriaMetrics Cloud Console",
           "isRequired": false,
           "format": "string",
           "isSecret": true

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -5,33 +5,101 @@ startCommand:
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
-    (config) => ({
-      command: 'mcp-victoriametrics',
-      args: [],
-      env: {
-        VM_INSTANCE_ENTRYPOINT: config.vmInstanceEntrypoint,
-        VM_INSTANCE_TYPE: config.vmInstanceType,
-        ...(config.vmInstanceBearerToken ? {VM_INSTANCE_BEARER_TOKEN: config.vmInstanceBearerToken} : {}),
+    (config) => {
+      const env = {};
+
+      if (config.vmEnvironments && Object.keys(config.vmEnvironments).length > 0) {
+        const environmentNames = Object.keys(config.vmEnvironments);
+        env.VM_ENVIRONMENTS = environmentNames.join(',');
+        if (config.vmDefaultEnvironment) {
+          env.VM_DEFAULT_ENVIRONMENT = config.vmDefaultEnvironment;
+        }
+
+        for (const [name, value] of Object.entries(config.vmEnvironments)) {
+          const suffix = name.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+          const prefix = `VM_INSTANCE_${suffix}_`;
+          env[`${prefix}ENTRYPOINT`] = value.entrypoint;
+          env[`${prefix}TYPE`] = value.type;
+          if (value.bearerToken) {
+            env[`${prefix}BEARER_TOKEN`] = value.bearerToken;
+          }
+          if (value.headers && value.headers.length > 0) {
+            env[`${prefix}HEADERS`] = value.headers.join(',');
+          }
+          if (value.defaultTenantId) {
+            env[`${prefix}DEFAULT_TENANT_ID`] = value.defaultTenantId;
+          }
+        }
+      } else {
+        env.VM_INSTANCE_ENTRYPOINT = config.vmInstanceEntrypoint;
+        env.VM_INSTANCE_TYPE = config.vmInstanceType;
+        if (config.vmInstanceBearerToken) {
+          env.VM_INSTANCE_BEARER_TOKEN = config.vmInstanceBearerToken;
+        }
       }
-    })
+
+      return {
+        command: 'mcp-victoriametrics',
+        args: [],
+        env,
+      };
+    }
   configSchema:
     # JSON Schema defining the configuration options for the MCP.
     type: object
-    required:
-      - vmInstanceEntrypoint
-      - vmInstanceType
     properties:
       vmInstanceEntrypoint:
         type: string
         description: URL to VictoriaMetrics instance
       vmInstanceType:
-        type:  string
+        type: string
         enum: [cluster, single]
         description: Type of VictoriaMetrics instance (cluster/single)
       vmInstanceBearerToken:
         type: string
         default: ""
         description: Authentication token for VictoriaMetrics API
+      vmDefaultEnvironment:
+        type: string
+        default: ""
+        description: Default environment used when a tool call omits env
+      vmEnvironments:
+        type: object
+        minProperties: 1
+        description: Named VictoriaMetrics environments exposed by a single MCP instance
+        additionalProperties:
+          type: object
+          required:
+            - entrypoint
+            - type
+          properties:
+            entrypoint:
+              type: string
+              description: URL to the VictoriaMetrics instance for this environment
+            type:
+              type: string
+              enum: [cluster, single]
+              description: Type of VictoriaMetrics instance (cluster/single) for this environment
+            bearerToken:
+              type: string
+              default: ""
+              description: Authentication token for this environment
+            headers:
+              type: array
+              default: []
+              description: Custom headers for this environment in key=value format
+              items:
+                type: string
+            defaultTenantId:
+              type: string
+              default: ""
+              description: Default tenant ID for this environment
+    oneOf:
+      - required:
+          - vmInstanceEntrypoint
+          - vmInstanceType
+      - required:
+          - vmEnvironments
   exampleConfig:
     vmInstanceEntrypoint: https://play.victoriametrics.com
     vmInstanceType: cluster


### PR DESCRIPTION
Implemented support for configuring multiple VictoriaMetrics environments using `VM_ENVIRONMENTS`, `VM_DEFAULT_ENVIRONMENT`, and `VM_INSTANCE_<ENV>_` environment variables.

**Key changes:**
- Refactored config to support named environments with ASCII-only names.
- Added 'env' and 'environment' (alias) parameters to all tools.
- Updated request routing to select the target instance based on tool arguments.
- Dynamically inject environment guidance into MCP server instructions.
- Aligned Helm, Smithery, and server.json metadata.
- Fixed compilation error in hooks due to upstream mcp-go changes.
- Added comprehensive unit tests for configuration and routing.

There is a complementary PR/branch in `mcp-victorialogs` so things are consistent between the MCP:
https://github.com/VictoriaMetrics/mcp-victorialogs/pull/71