### PR TITLE
feat: add Bearer Token authentication for HTTP endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ docker run -d --name mcp-victoriametrics \
   -e VM_INSTANCE_TYPE=cluster \
   -e MCP_SERVER_MODE=sse \
   -e MCP_LISTEN_ADDR=:8080 \
+  -e MCP_AUTH_TOKEN=your-secret-token \
   -p 8080:8080 \
   ghcr.io/victoriametrics/mcp-victoriametrics
 ```
@@ -143,6 +144,7 @@ MCP Server for VictoriaMetrics is configured via environment variables:
 | `MCP_DISABLED_TOOLS`                     | Comma-separated list of tools to disable                                                                                                                                                                                                                            | No                                     | 'export,flags,metric_relabel_debug,downsampling_filters_debug,retention_filters_debug,test_rules' | -                      |
 | `MCP_DISABLE_RESOURCES`                  | Disable all resources (documentation tool will continue to work)                                                                                                                                                                                                    | No                                     | `false`                                                                                           | `false`, `true`        |                   
 | `MCP_HEARTBEAT_INTERVAL`                 | Defines the heartbeat interval for the streamable-http protocol. <br /> It means the MCP server will send a heartbeat to the client through the GET connection, <br /> to keep the connection alive from being closed by the network infrastructure (e.g. gateways) | No                                     | `30s`                                                                                             | -                      |
+| `MCP_AUTH_TOKEN`                         | Bearer token for authenticating incoming MCP requests (only applies in `sse`/`http` modes). Public paths (`/health/*`, `/metrics`, `/`, static assets) are excluded from authentication.                                                                           | No                                     | -                                                                                                 | -                      |
 | `MCP_LOG_FORMAT`                         | Log output format                                                                                                                                                                                                                                                   | No                                     | `text`                                                                                            | `text`, `json`         |
 | `MCP_LOG_LEVEL`                          | Minimum log level                                                                                                                                                                                                                                                   | No                                     | `info`                                                                                            | `debug`, `info`, `warn`, `error` |
 
@@ -184,6 +186,9 @@ export VMC_API_KEY="<you-api-key>"
 # Server mode
 export MCP_SERVER_MODE="sse"
 export MCP_LISTEN_ADDR="0.0.0.0:8080"
+
+# Authentication (optional, only for sse/http modes)
+export MCP_AUTH_TOKEN="your-secret-token"
 
 # Custom headers for authentication (e.g., behind a reverse proxy)
 # Expected syntax is key=value separated by commas
@@ -661,7 +666,7 @@ You can use `MCP_PASSTHROUGH_HEADERS` parameter in the MCP Server together with 
 - [x] Enabling/disabling tools via configuration (done in [`v0.0.8`](https://github.com/VictoriaMetrics/mcp-victoriametrics/releases/tag/v0.0.8))
 - [ ] Tools for Alertmanager APIs [#6](https://github.com/VictoriaMetrics/mcp-victoriametrics/issues/6)
 - [x] Support for [metrics metadata](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/2974) in case of implementation in VictoriaMetrics
-- [ ] Support authentication
+- [x] Support authentication
 - [x] Add static index page with description and links to documentation
 
 ## Mentions

--- a/cmd/mcp-victoriametrics/auth/middleware.go
+++ b/cmd/mcp-victoriametrics/auth/middleware.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// Middleware returns an HTTP middleware that validates the Authorization: Bearer <token>
+// header on incoming requests. It skips authentication for /health/*, /metrics,
+// and the root / (SPA static files). If the token is empty, the middleware is a no-op.
+func Middleware(token string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip auth for non-sensitive endpoints
+			if isPublicPath(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				slog.Warn("Auth failed: missing Authorization header",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"remote_addr", r.RemoteAddr,
+				)
+				writeUnauthorized(w, "missing Authorization header")
+				return
+			}
+
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+				slog.Warn("Auth failed: invalid Authorization header format",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"remote_addr", r.RemoteAddr,
+				)
+				writeUnauthorized(w, "invalid Authorization header format")
+				return
+			}
+
+			provided := parts[1]
+			expected := token
+
+			if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+				slog.Warn("Auth failed: invalid token",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"remote_addr", r.RemoteAddr,
+				)
+				writeUnauthorized(w, "invalid token")
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func isPublicPath(path string) bool {
+	if path == "/" {
+		return true
+	}
+	if strings.HasPrefix(path, "/health") {
+		return true
+	}
+	if path == "/metrics" {
+		return true
+	}
+	// Static assets served by SPA handler (files with extensions)
+	if strings.Contains(path, ".") && !strings.HasPrefix(path, "/mcp") {
+		return true
+	}
+	return false
+}
+
+func writeUnauthorized(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error": message,
+	})
+}

--- a/cmd/mcp-victoriametrics/auth/middleware.go
+++ b/cmd/mcp-victoriametrics/auth/middleware.go
@@ -80,7 +80,9 @@ func isPublicPath(path string) bool {
 func writeUnauthorized(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
-	json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"error": message,
-	})
+	}); err != nil {
+		slog.Error("Failed to write unauthorized response", "error", err)
+	}
 }

--- a/cmd/mcp-victoriametrics/config/config.go
+++ b/cmd/mcp-victoriametrics/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	customHeaders      map[string]string
 	passthroughHeaders []string
 	defaultTenantID    string
+	authToken          string
 
 	// Logging configuration
 	logFormat string
@@ -134,6 +135,7 @@ func InitConfig() (*Config, error) {
 		disableResources:   disableResources,
 		customHeaders:      customHeadersMap,
 		passthroughHeaders: passthroughHeaders,
+		authToken:          os.Getenv("MCP_AUTH_TOKEN"),
 		logFormat:          logFormat,
 		logLevel:           logLevel,
 		defaultTenantID:    "0",
@@ -272,4 +274,8 @@ func (c *Config) LogLevel() string {
 
 func (c *Config) DefaultTenantID() string {
 	return c.defaultTenantID
+}
+
+func (c *Config) AuthToken() string {
+	return c.authToken
 }

--- a/cmd/mcp-victoriametrics/main.go
+++ b/cmd/mcp-victoriametrics/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/VictoriaMetrics/metrics"
 
+	"github.com/VictoriaMetrics/mcp-victoriametrics/cmd/mcp-victoriametrics/auth"
 	"github.com/VictoriaMetrics/mcp-victoriametrics/cmd/mcp-victoriametrics/config"
 	"github.com/VictoriaMetrics/mcp-victoriametrics/cmd/mcp-victoriametrics/hooks"
 	"github.com/VictoriaMetrics/mcp-victoriametrics/cmd/mcp-victoriametrics/logging"
@@ -185,9 +186,16 @@ Try not to second guess information - if you don't know something or lack inform
 	}
 
 	ongoingCtx, stopOngoingGracefully := context.WithCancel(context.Background())
+
+	var handler http.Handler = mux
+	if authToken := c.AuthToken(); authToken != "" {
+		slog.Info("Authentication enabled", "token_configured", true)
+		handler = auth.Middleware(authToken)(mux)
+	}
+	handler = logger.Middleware(handler)
 	hs := &http.Server{
 		Addr:    c.ListenAddr(),
-		Handler: logger.Middleware(mux),
+		Handler: handler,
 		BaseContext: func(_ net.Listener) context.Context {
 			return ongoingCtx
 		},


### PR DESCRIPTION
Add optional authentication middleware that validates Authorization: Bearer <token>
header on incoming requests when MCP_AUTH_TOKEN environment variable is set. Public paths (/health, /metrics, /, static assets) are excluded from auth. Uses constant-time comparison to prevent timing attacks.