### PR TITLE
Allow numeric tenant IDs in MCP tool parameters

### DIFF
--- a/cmd/mcp-victoriametrics/tools/active_queries.go
+++ b/cmd/mcp-victoriametrics/tools/active_queries.go
@@ -36,12 +36,7 @@ This information is obtained from the "/api/v1/status/active_queries" HTTP endpo
 	}
 	if c.IsCluster() || c.IsCloud() {
 		options = append(options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the active queries will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the active queries will be displayed"),
 		)
 	}
 	return mcp.NewTool(toolNameActiveQueries, options...)

--- a/cmd/mcp-victoriametrics/tools/alerts.go
+++ b/cmd/mcp-victoriametrics/tools/alerts.go
@@ -39,12 +39,7 @@ func toolAlerts(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the list of alerts will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the list of alerts will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/export.go
+++ b/cmd/mcp-victoriametrics/tools/export.go
@@ -37,12 +37,7 @@ func toolExport(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the data will be exported"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the data will be exported"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/labels.go
+++ b/cmd/mcp-victoriametrics/tools/labels.go
@@ -36,12 +36,7 @@ func toolLabels(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the list of labels will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the list of labels will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/labelvalues.go
+++ b/cmd/mcp-victoriametrics/tools/labelvalues.go
@@ -36,12 +36,7 @@ func toolLabelsValues(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the list of label values will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the list of label values will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/metrics.go
+++ b/cmd/mcp-victoriametrics/tools/metrics.go
@@ -35,12 +35,7 @@ func toolMetrics(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the list of metrics will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the list of metrics will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/metrics_metadata.go
+++ b/cmd/mcp-victoriametrics/tools/metrics_metadata.go
@@ -38,12 +38,7 @@ func toolMetricsMetadata(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the list of metrics will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the list of metrics will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/metricstats.go
+++ b/cmd/mcp-victoriametrics/tools/metricstats.go
@@ -36,12 +36,7 @@ func toolMetricStats(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the metric query statistics will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the metric query statistics will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/prettify_query.go
+++ b/cmd/mcp-victoriametrics/tools/prettify_query.go
@@ -36,12 +36,7 @@ func toolPrettifyQuery(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the data will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the data will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/query.go
+++ b/cmd/mcp-victoriametrics/tools/query.go
@@ -35,12 +35,7 @@ func toolQuery(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the data will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the data will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/query_range.go
+++ b/cmd/mcp-victoriametrics/tools/query_range.go
@@ -35,12 +35,7 @@ func toolQueryRange(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the data will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the data will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/rules.go
+++ b/cmd/mcp-victoriametrics/tools/rules.go
@@ -35,12 +35,7 @@ func toolRules(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the list of rules will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the list of rules will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/series.go
+++ b/cmd/mcp-victoriametrics/tools/series.go
@@ -35,12 +35,7 @@ func toolSeries(c *config.Config) mcp.Tool {
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the list of time series will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the list of time series will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/top_queries.go
+++ b/cmd/mcp-victoriametrics/tools/top_queries.go
@@ -42,12 +42,7 @@ This information is obtained from the "/api/v1/status/top_queries" HTTP endpoint
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the top queries will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the top queries will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/tsdb_status.go
+++ b/cmd/mcp-victoriametrics/tools/tsdb_status.go
@@ -44,12 +44,7 @@ This tool returns TSDB stats from "/api/v1/status/tsdb" endpoint of VictoriaMetr
 	if c.IsCluster() || c.IsCloud() {
 		options = append(
 			options,
-			mcp.WithString("tenant",
-				mcp.Title("Tenant name"),
-				mcp.Description("Name of the tenant for which the TSDB stats will be displayed"),
-				mcp.DefaultString("0"),
-				mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`),
-			),
+			withTenantParam("Name of the tenant for which the TSDB stats will be displayed"),
 		)
 	}
 	options = append(

--- a/cmd/mcp-victoriametrics/tools/utils.go
+++ b/cmd/mcp-victoriametrics/tools/utils.go
@@ -265,6 +265,15 @@ func GetTextBodyForRequest(req *http.Request, _ *config.Config, f ...func(s stri
 	return mcp.NewToolResultText(result)
 }
 
+// withTenantParam adds the tenant property to the tool input schema.
+func withTenantParam(description string) mcp.ToolOption {
+	return mcp.WithString("tenant",
+		mcp.Title("Tenant name"),
+		mcp.Description(description),
+		mcp.DefaultString("0"),
+		mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`))
+}
+
 type ToolReqParamType interface {
 	string | float64 | bool | []string | []any
 }

--- a/cmd/mcp-victoriametrics/tools/utils.go
+++ b/cmd/mcp-victoriametrics/tools/utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -232,7 +233,7 @@ func getSelectURL(ctx context.Context, cfg *config.Config, tcr mcp.CallToolReque
 	}
 
 	// Cluster mode
-	tenant, err := GetToolReqParam[string](tcr, "tenant", false)
+	tenant, err := GetToolReqTenantParam(tcr)
 	if err != nil {
 		return "", fmt.Errorf("failed to get tenant parameter: %v", err)
 	}
@@ -266,12 +267,25 @@ func GetTextBodyForRequest(req *http.Request, _ *config.Config, f ...func(s stri
 }
 
 // withTenantParam adds the tenant property to the tool input schema.
+// Allows both a string and an integer. Integers are coerced to strings
 func withTenantParam(description string) mcp.ToolOption {
-	return mcp.WithString("tenant",
-		mcp.Title("Tenant name"),
-		mcp.Description(description),
-		mcp.DefaultString("0"),
-		mcp.Pattern(`^([0-9]+)(:[0-9]+)?$`))
+	return func(t *mcp.Tool) {
+		t.InputSchema.Properties["tenant"] = map[string]any{
+			"title":       "Tenant name",
+			"description": description,
+			"default":     "0",
+			"anyOf": []map[string]any{
+				{
+					"type":    "string",
+					"pattern": `^([0-9]+)(:[0-9]+)?$`,
+				},
+				{
+					"type":    "integer",
+					"minimum": 0,
+				},
+			},
+		}
+	}
 }
 
 type ToolReqParamType interface {
@@ -290,6 +304,21 @@ func GetToolReqParam[T ToolReqParamType](tcr mcp.CallToolRequest, param string, 
 		return value, fmt.Errorf("%s param is required", param)
 	}
 	return value, nil
+}
+
+// GetToolReqTenantParam gets the tenant parameter as string or float. If it's a float,
+// it's coerced to a string.
+func GetToolReqTenantParam(tcr mcp.CallToolRequest) (string, error) {
+	tenant, err := GetToolReqParam[string](tcr, "tenant", false)
+	if err == nil {
+		return tenant, nil
+	}
+
+	tenantNumber, numberErr := GetToolReqParam[float64](tcr, "tenant", false)
+	if numberErr == nil {
+		return strconv.FormatFloat(tenantNumber, 'f', -1, 64), nil
+	}
+	return "", err
 }
 
 func withCloudAccessKey(ctx context.Context, tcr mcp.CallToolRequest) context.Context {

--- a/cmd/mcp-victoriametrics/tools/utils_test.go
+++ b/cmd/mcp-victoriametrics/tools/utils_test.go
@@ -324,3 +324,61 @@ func TestGetSelectURLWithDefaultTenant(t *testing.T) {
 		})
 	}
 }
+
+func TestGetToolReqTenantParam(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          map[string]any
+		required      bool
+		expectedValue string
+		expectError   bool
+	}{
+		{
+			name:          "string tenant",
+			args:          map[string]any{"tenant": "100:200"},
+			expectedValue: "100:200",
+		},
+		{
+			name:          "numeric tenant",
+			args:          map[string]any{"tenant": float64(123)},
+			expectedValue: "123",
+		},
+		{
+			name:          "numeric tenant",
+			args:          map[string]any{"tenant": float64(0)},
+			expectedValue: "0",
+		},
+		{
+			name:          "numeric tenant",
+			args:          map[string]any{"tenant": float64(421598)},
+			expectedValue: "421598",
+		},
+		{
+			name:          "missing optional tenant",
+			expectedValue: "",
+		},
+		{
+			name:        "invalid tenant type",
+			args:        map[string]any{"tenant": true},
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tcr := mcp.CallToolRequest{}
+			tcr.Params.Arguments = test.args
+
+			value, err := GetToolReqTenantParam(tcr)
+			if test.expectError && err == nil {
+				t.Fatal("Expected an error, got nil")
+			}
+			if !test.expectError && err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+			if value != test.expectedValue {
+				t.Errorf("Expected %q, got %q", test.expectedValue, value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What changes
In addition to strings, accept numeric tenant IDs as parameter in MCP tools.

### Why?
We run HolmesGPT connected to mcp-victoriametrics, using Qwen 3.6 as model. When reviewing our traces, I noticed frequent failures due to the model calling tools with an integer as tenant ID. We tried to steer the model using system prompts and skills, which decreased the frequency of failures, but did not solve the problem entirely. 

### Implementation
Update the schema to expand the type from `string` to `anyOf[string, integer]`. The schema specifies integer with minimum 0, but the implementation uses floats. I did not add validation to check fractional or negative numbers, as I saw no validation to prevent clients from passing a string like "-1.75". Let me know if you'd like me to add such validation. 

Added unit tests covering:
  - String tenant IDs
  - Numeric tenant IDs
  - Zero
  - Larger numeric tenant IDs
  - Missing optional tenant values
  - Invalid tenant types


* [X] Reviewed the code of conduct
